### PR TITLE
Pap add allergen show symptom detail

### DIFF
--- a/src/app/(protected)/dashboard/_components/UserDashboard/_components/PersonalAllergyProfile/page.tsx
+++ b/src/app/(protected)/dashboard/_components/UserDashboard/_components/PersonalAllergyProfile/page.tsx
@@ -22,6 +22,7 @@ import { PAPAllergen, UpdatePAPAllergen$Params, UpdatePAPWithUserIdFetcher$Param
 import { SymptomDetailModal } from "@/components/container/SymptomList/_components/symptom-detail-modal"
 import { getTypeColor } from "@/lib/client-side-utils"
 import { AllergenDetailModal } from "@/components/container/AllergenList/_components/allergen-detail-modal"
+import { useSymptomDetail } from "@/app/context/symptom-detail-context"
 
 interface PersonalAllergyProfileProps {
   pAP: DisplayPAP
@@ -39,7 +40,7 @@ export function PersonalAllergyProfile({ pAP, availableSymptoms, potentialCrossA
   const [isEditingProfile, setIsEditingProfile] = useState(false)
   const [editingAllergen, setEditingAllergen] = useState<string | null>(null)
   const [showAddAllergen, setShowAddAllergen] = useState(false)
-  const [selectedSymptom, setSelectedSymptom] = useState<Symptom | null>(null)
+  const { showSymptomDetail } = useSymptomDetail();
   const [selectedAllergen, setSelectedAllergen] = useState<Allergen | undefined>(undefined);
 
   const [profileData, setProfileData] = useState({
@@ -222,7 +223,8 @@ export function PersonalAllergyProfile({ pAP, availableSymptoms, potentialCrossA
                             className="text-xs hover:bg-cyan-100 hover:cursor-pointer"
                             onClick={(e) => {
                               e.stopPropagation();
-                              setSelectedSymptom(Symptom.parse({id: symptom.symptomId, ...symptom}));
+                              const fullSymptom = Symptom.parse({ id: symptom.symptomId, ...symptom });
+                              showSymptomDetail(fullSymptom);
                             }}
                           >
                             {symptom.name[localLanguage]}
@@ -332,11 +334,6 @@ export function PersonalAllergyProfile({ pAP, availableSymptoms, potentialCrossA
           </div>
         </DialogContent>
       </Dialog>
-
-      {selectedSymptom && <SymptomDetailModal
-        symptom={selectedSymptom}
-        onClose={() => setSelectedSymptom(null)}
-      />}
 
       {editingAllergen && (
         <AllergenEditModal

--- a/src/app/(protected)/dashboard/_components/UserDashboard/_components/PersonalAllergyProfile/page.tsx
+++ b/src/app/(protected)/dashboard/_components/UserDashboard/_components/PersonalAllergyProfile/page.tsx
@@ -220,7 +220,10 @@ export function PersonalAllergyProfile({ pAP, availableSymptoms, potentialCrossA
                             key={symptom.symptomId} 
                             variant="outline" 
                             className="text-xs hover:bg-cyan-100 hover:cursor-pointer"
-                            onClick={() => setSelectedSymptom(Symptom.parse({id: symptom.symptomId, ...symptom}))}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setSelectedSymptom(Symptom.parse({id: symptom.symptomId, ...symptom}));
+                            }}
                           >
                             {symptom.name[localLanguage]}
                           </Badge>

--- a/src/app/(protected)/dashboard/_components/UserDashboard/page.tsx
+++ b/src/app/(protected)/dashboard/_components/UserDashboard/page.tsx
@@ -14,6 +14,7 @@ import { PAPAllergen, UpdatePAPWithUserIdFetcher$Params } from "@/modules/comman
 import { httpPut$UpdatePAPWithUserId } from "@/modules/commands/UpdatePAPWithUserId/fetcher"
 import { SymptomList } from "@/components/container/SymptomList/page"
 import { AllergenList } from "@/components/container/AllergenList/page"
+import { SymptomDetailProvider } from "@/app/context/symptom-detail-context"
 
 export default function UserDashboard() {
   const t = useTranslations('userDashboard')
@@ -148,14 +149,17 @@ export default function UserDashboard() {
           </TabsList>
 
           <TabsContent value="profile">
-            <PersonalAllergyProfile
-              pAP={pAP} 
-              availableSymptoms={symptoms} 
-              potentialCrossAllergens={potentialCrossAllergens} 
-              availableAllergens={availableAllergens} 
-              allergens={allergens}
-              onUpdate={handlePAPUpdate}
-            />
+            <SymptomDetailProvider>
+              <PersonalAllergyProfile
+                pAP={pAP} 
+                availableSymptoms={symptoms} 
+                potentialCrossAllergens={potentialCrossAllergens} 
+                availableAllergens={availableAllergens} 
+                allergens={allergens}
+                onUpdate={handlePAPUpdate}
+              />
+            </SymptomDetailProvider>
+            
           </TabsContent>
 
           <TabsContent value="wiki" className="space-y-6">

--- a/src/app/context/symptom-detail-context.tsx
+++ b/src/app/context/symptom-detail-context.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import { Symptom } from "@/modules/business-types";
+import { SymptomDetailModal } from "@/components/container/SymptomList/_components/symptom-detail-modal";
+
+// Define the shape of the context data
+interface SymptomDetailContextType {
+  showSymptomDetail: (symptom: Symptom) => void;
+}
+
+// Create the context with a default value
+const SymptomDetailContext = createContext<SymptomDetailContextType | undefined>(undefined);
+
+// Create the Provider component
+export function SymptomDetailProvider({ children }: { children: ReactNode }) {
+  const [selectedSymptom, setSelectedSymptom] = useState<Symptom | null>(null);
+
+  const showSymptomDetail = (symptom: Symptom) => {
+    setSelectedSymptom(symptom);
+  };
+
+  const handleClose = () => {
+    setSelectedSymptom(null);
+  };
+
+  return (
+    <SymptomDetailContext.Provider value={{ showSymptomDetail }}>
+      {children}
+
+      {/* The Modal is now rendered here, controlled by this provider */}
+      {selectedSymptom && (
+        <SymptomDetailModal symptom={selectedSymptom} onClose={handleClose} />
+      )}
+    </SymptomDetailContext.Provider>
+  );
+}
+
+// Create a custom hook for easy access to the context
+export function useSymptomDetail() {
+  const context = useContext(SymptomDetailContext);
+  if (context === undefined) {
+    throw new Error("useSymptomDetail must be used within a SymptomDetailProvider");
+  }
+  return context;
+}

--- a/src/components/grouped-symptoms-select.tsx
+++ b/src/components/grouped-symptoms-select.tsx
@@ -12,6 +12,8 @@ import Typography from '@mui/material/Typography'
 import { ChevronDown, Info, X } from "lucide-react"
 import { Button } from "./ui/button"
 import { Badge } from "./ui/badge"
+import { useSymptomDetail } from "@/app/context/symptom-detail-context"
+import { Symptom } from "@/modules/business-types"
 
 interface GroupedSymptomSelectProps<T> {
   items: T[]
@@ -48,6 +50,8 @@ export function GroupedSymptomSelect<T>({
   const removeItem = (itemId: string) => {
     onSelectionChange(selectedItems.filter((id) => id !== itemId))
   }
+
+  const { showSymptomDetail } = useSymptomDetail();
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
@@ -99,7 +103,12 @@ export function GroupedSymptomSelect<T>({
                         <label htmlFor={itemId} className="text-sm cursor-pointer flex-1">
                           {getItemLabel(item)}
                         </label>
-                        <Info id={itemId} opacity={0.5} className="cursor-pointer hover:opacity-70">
+                        <Info
+                          id={itemId} 
+                          opacity={0.5} 
+                          className="cursor-pointer hover:opacity-70"
+                          onClick={() => showSymptomDetail(item as unknown as Symptom)}
+                        >
                         </Info>
                       </div>
                   );

--- a/src/components/grouped-symptoms-select.tsx
+++ b/src/components/grouped-symptoms-select.tsx
@@ -9,7 +9,7 @@ import AccordionDetails from '@mui/material/AccordionDetails'
 import { Checkbox } from "@/components/ui/checkbox"
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import { ChevronDown, X } from "lucide-react"
+import { ChevronDown, Info, X } from "lucide-react"
 import { Button } from "./ui/button"
 import { Badge } from "./ui/badge"
 
@@ -94,12 +94,13 @@ export function GroupedSymptomSelect<T>({
                   return (
                     <div key={itemId} className="flex items-center space-x-2 p-2 hover:bg-cyan-50 rounded">
                         <Checkbox id={itemId} checked={isSelected} onCheckedChange={(checked) => {
-                          console.log(checked);
                           toggleItem(itemId);
                         }} />
                         <label htmlFor={itemId} className="text-sm cursor-pointer flex-1">
                           {getItemLabel(item)}
                         </label>
+                        <Info id={itemId} opacity={0.5} className="cursor-pointer hover:opacity-70">
+                        </Info>
                       </div>
                   );
                 })


### PR DESCRIPTION
## Title
Show symptom details in patient profile by clicking on Info button.

---

## Description
- Briefly explain **what this PR does**.
- Add context if needed (why the change is necessary, what problem it solves).
- Mention related issues/tickets if applicable.

---

## Changes
- [x] Added UI for symptom info button  
- [x] Fixed click propagation on symptom detail modal  
- [x] Implemented "show symptom detail" feature  

---

## Screenshots (if applicable)
None

---

## How to Test
1. Go to **PAP** screen, access Edit Allergen / Add Allergen page. 
2. Expand Symptom accordions, click the **info button** next to a symptom  
3. Confirm that the detail modal opens  
4. Check that clicks outside the modal close it without unwanted propagation  

---

## Checklist
- [ ] Code follows project conventions  
- [ ] Tests added/updated  
- [x] UI verified manually  
- [ ] No console errors/warnings -> ❌ Error (IntlError: MISSING_MESSAGE: Could not resolve `detailModals.organ` in messages for locale `en`.)

---