### PR TITLE
feat:group symptoms by organs in selection

### DIFF
--- a/src/components/grouped-symptoms-select.tsx
+++ b/src/components/grouped-symptoms-select.tsx
@@ -24,7 +24,7 @@ interface GroupedSymptomSelectProps<T> {
   label: string
 }
 
-export function GroupedSymptomSelect<T>({
+export function GroupedSymptomSelect<T extends { organ: string }>({
   items,
   selectedItems,
   onSelectionChange,
@@ -34,9 +34,18 @@ export function GroupedSymptomSelect<T>({
 }: GroupedSymptomSelectProps<T>) {
   const t = useTranslations('common');
 
+  const groupedByOrgan = items.reduce((symptomGroups, item) => {
+    const organ = item.organ;
+    if (!symptomGroups[organ]) {
+      symptomGroups[organ] = [];
+    };
+    symptomGroups[organ].push(item);
+    return symptomGroups;
+  }, {} as Record<string, T[]>);
+
   const symptomGroups = {
     "All Symptoms": items,
-    "Oral": items.slice(5,9),
+    ...groupedByOrgan
   };
 
   const toggleItem = (itemId: string) => {


### PR DESCRIPTION
## Group symptoms by organs in selection.
### Description
This PR includes the logic that group symptoms by "organ" in PAP Edit/Add Allergen.

---

### Changes
- [x] Added logic to group symptoms by "organ" in `group-symptoms-select.tsx`.

---

### Screenshots (if applicable)
None

---

### How to Test
1. Go to **PAP** screen, access Edit Allergen / Add Allergen page. 
2. Confirm that the Symptom accordions are divided into "organ" groups.

---

### Checklist
- [ ] Code follows project conventions  -> ⚠️ used `@mui` instead of `@shadcn` for Symptom Accordions.
- [ ] Tests added/updated  
- [x] UI verified manually  
- [ ] No console errors/warnings -> ❌ Error (Error: MISSING_MESSAGE: Could not resolve `detailModals.organ` in messages for locale `vi`.)

---